### PR TITLE
Initial web structure with Next.js and Tailwind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+package-lock.json

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,16 @@
     "next": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "tailwindcss": "^3.0.0"
+    "swr": "^2.3.3",
+    "tailwindcss": "^3.0.0",
+    "xlsx": "^0.18.5"
+  },
+  "devDependencies": {
+    "@types/node": "22.15.30",
+    "@types/react": "19.1.7",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.4",
+    "postcss-loader": "^8.1.1",
+    "typescript": "5.8.3"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+const Navbar = () => (
+  <nav className="flex space-x-4 p-4 bg-fondo text-texto">
+    <Link href="/">Inicio</Link>
+    <Link href="/sobre-nosotros">Sobre Nosotros</Link>
+    <Link href="/productos">Productos</Link>
+    <Link href="/tips-y-estilo">Tips & Estilo</Link>
+    <Link href="/contacto">Contacto</Link>
+  </nav>
+);
+
+export default Navbar;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,14 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+import Navbar from '../components/Navbar';
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <>
+      <Navbar />
+      <Component {...pageProps} />
+    </>
+  );
+}
+
+export default MyApp;

--- a/src/pages/api/productos.ts
+++ b/src/pages/api/productos.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import path from 'path';
+import fs from 'fs';
+import xlsx from 'xlsx';
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  const workbook = xlsx.readFile(path.join(process.cwd(), 'src/data/productos.xlsx'));
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  const data = xlsx.utils.sheet_to_json(sheet, { defval: '' });
+
+  const images = fs.readdirSync(path.join(process.cwd(), 'public/imagenes'));
+
+  const productos = (data as any[]).map((row) => {
+    const codigo = row['Código'];
+    const imgs = images.filter((img) => img.startsWith(codigo));
+    const principal = imgs.find((i) => !i.includes(' ')) || imgs[0];
+    return {
+      ...row,
+      imagenes: imgs.map((i) => `/imagenes/${i}`),
+      imagenPrincipal: principal ? `/imagenes/${principal}` : '',
+    };
+  });
+
+  res.status(200).json(productos);
+}

--- a/src/pages/contacto.tsx
+++ b/src/pages/contacto.tsx
@@ -1,0 +1,12 @@
+export default function Contacto() {
+  return (
+    <div className="p-8 space-y-4 text-center">
+      <h1 className="text-3xl">Contacto</h1>
+      <p>¿Querés vender MARÉ en tu comercio? ¿Querés saber dónde encontrar nuestros productos? ¡Contactanos!</p>
+      <div className="space-x-4">
+        <a href="https://wa.me/549123456789" className="underline">Enviar WhatsApp</a>
+        <a href="https://instagram.com" className="underline">Instagram</a>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,37 @@
+import Image from 'next/image';
+import fs from 'fs';
+import path from 'path';
+import contenido from '../data/contenido_web.json';
+
+export default function Home() {
+  const destacados = (contenido as any[]).filter(c => c.destacado);
+  return (
+    <div className="text-center">
+      <div className="relative w-full h-96 overflow-hidden">
+        <video
+          className="object-cover w-full h-full"
+          src="/video-institucional.mp4"
+          autoPlay
+          loop
+          muted
+        />
+        <div className="absolute inset-0 flex flex-col items-center justify-center text-4xl text-texto">
+          <Image src="/logo-mare.png" alt="MARÉ" width={200} height={100} />
+          <p>Tu estilo en cada detalle</p>
+        </div>
+      </div>
+      <div className="p-4">
+        <h2 className="text-2xl mb-4">Destacados</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {destacados.map((d, i) => (
+            <div key={i} className="border p-2 rounded">
+              <Image src={`/${d.imagen}`} alt={d.titulo} width={300} height={200} className="mx-auto" />
+              <h3 className="mt-2">{d.titulo}</h3>
+              <p>{d.texto}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/productos.tsx
+++ b/src/pages/productos.tsx
@@ -1,0 +1,28 @@
+import useSWR from 'swr';
+import Image from 'next/image';
+
+const fetcher = (url: string) => fetch(url).then(res => res.json());
+
+export default function Productos() {
+  const { data } = useSWR('/api/productos', fetcher);
+
+  if (!data) return <p className="p-8">Cargando...</p>;
+
+  return (
+    <div className="p-8 grid grid-cols-1 md:grid-cols-3 gap-4">
+      {data.map((prod: any) => (
+        <div key={prod.Código} className="border p-2 rounded">
+          <Image src={prod.imagenPrincipal} alt={prod.Nombre} width={300} height={200} className="mx-auto" />
+          <h3 className="text-xl mt-2">{prod.Nombre}</h3>
+          <p>{prod.Descripción}</p>
+          <a
+            className="underline"
+            href={`https://wa.me/549123456789?text=Hola,%20me%20interesa%20este%20producto:%20${prod.Código}`}
+          >
+            Me interesa
+          </a>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/sobre-nosotros.tsx
+++ b/src/pages/sobre-nosotros.tsx
@@ -1,0 +1,9 @@
+export default function SobreNosotros() {
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-3xl">Sobre Nosotros</h1>
+      <p>Breve historia de MARÉ y Feraben SRL.</p>
+      <p>Misión, visión y valores orientados al diseño y calidad.</p>
+    </div>
+  );
+}

--- a/src/pages/tips-y-estilo.tsx
+++ b/src/pages/tips-y-estilo.tsx
@@ -1,0 +1,20 @@
+import contenido from '../data/contenido_web.json';
+import Image from 'next/image';
+
+export default function Tips() {
+  const tips = contenido as any[];
+  return (
+    <div className="p-8 space-y-8">
+      <h1 className="text-3xl">Tips & Estilo</h1>
+      {tips.map((tip, i) => (
+        <div key={i} className="flex flex-col md:flex-row md:space-x-4 border p-4 rounded">
+          <Image src={`/${tip.imagen}`} alt={tip.titulo} width={300} height={200} />
+          <div>
+            <h2 className="text-xl">{tip.titulo}</h2>
+            <p>{tip.texto}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-fondo text-texto font-playfair;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,1 +1,15 @@
-module.exports = { content: ['./src/**/*.{js,ts,jsx,tsx}'], theme: { extend: {} }, plugins: [] }
+module.exports = {
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        fondo: '#E3D4C1',
+        texto: '#8F6A50',
+      },
+      fontFamily: {
+        playfair: ['\"Playfair Display\"', 'serif'],
+      },
+    },
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- setup Next.js with TypeScript and Tailwind
- add navbar and global styles
- create pages: inicio, sobre nosotros, productos, tips y estilo, contacto
- API route reads Excel and maps images from `/public/imagenes`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684765bb010c832e9bdb32e85853c193